### PR TITLE
Poseidon377 Merkle Tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,8 @@ dependencies = [
  "ark-relations",
  "ark-std",
  "decaf377",
+ "poseidon-parameters",
+ "poseidon377",
 ]
 
 [[package]]
@@ -281,10 +283,10 @@ dependencies = [
 [[package]]
 name = "decaf377"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2097c5f69d06259112bea2024ddc41095c5001b503448f84ac169efc7cc8fd75"
+source = "git+https://github.com/hu55a1n1/decaf377.git#0945efd1eaf5e2d45441eb99c6f3a0cb3b928512"
 dependencies = [
  "ark-bls12-377",
+ "ark-crypto-primitives",
  "ark-ec",
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -336,17 +338,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -431,9 +422,36 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "poseidon-parameters"
+version = "1.1.0"
+source = "git+https://github.com/dangush/poseidon377.git#61dc418b5f8296da4ca342f138c81b688e5808cb"
+dependencies = [
+ "decaf377",
+]
+
+[[package]]
+name = "poseidon-permutation"
+version = "1.1.0"
+source = "git+https://github.com/dangush/poseidon377.git#61dc418b5f8296da4ca342f138c81b688e5808cb"
+dependencies = [
+ "decaf377",
+ "poseidon-parameters",
+]
+
+[[package]]
+name = "poseidon377"
+version = "1.2.0"
+source = "git+https://github.com/dangush/poseidon377.git#61dc418b5f8296da4ca342f138c81b688e5808cb"
+dependencies = [
+ "decaf377",
+ "poseidon-parameters",
+ "poseidon-permutation",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -446,18 +464,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -487,9 +505,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "rustc_version"
@@ -502,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "sha2"
@@ -536,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -564,7 +579,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -600,21 +615,15 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zerocopy"
@@ -634,7 +643,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -654,5 +663,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +62,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "hashbrown",
+ "hashbrown 0.13.2",
  "itertools",
  "num-traits",
  "zeroize",
@@ -128,7 +134,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "hashbrown",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -214,6 +220,7 @@ dependencies = [
  "ark-r1cs-std",
  "ark-relations",
  "ark-std",
+ "decaf377",
 ]
 
 [[package]]
@@ -272,6 +279,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "decaf377"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2097c5f69d06259112bea2024ddc41095c5001b503448f84ac169efc7cc8fd75"
+dependencies = [
+ "ark-bls12-377",
+ "ark-ec",
+ "ark-ed-on-bls12-377",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "hex",
+ "num-bigint",
+ "once_cell",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +339,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +357,22 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itertools"
@@ -431,6 +487,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rustc_version"
@@ -550,6 +609,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ ark-relations = { version = "0.4.0", default-features = false }
 ark-r1cs-std = { version = "0.4.0", default-features = false }
 ark-ed-on-bls12-377 = { version = "0.4.0", default-features = false, features = ["r1cs"] }
 ark-crypto-primitives = { version = "0.4.0", features = ["merkle_tree", "r1cs"] }
+
+# decaf377 = { path = "../decaf377", default-features = true}
+decaf377 = { version = "0.10.1", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ ark-r1cs-std = { version = "0.4.0", default-features = false }
 ark-ed-on-bls12-377 = { version = "0.4.0", default-features = false, features = ["r1cs"] }
 ark-crypto-primitives = { version = "0.4.0", features = ["merkle_tree", "r1cs"] }
 
-# decaf377 = { path = "../decaf377", default-features = true}
-decaf377 = { version = "0.10.1", default-features = true }
+decaf377 = { git = "https://github.com/hu55a1n1/decaf377.git", default-features = false }
+poseidon377 = { git = "https://github.com/dangush/poseidon377.git", version = "1.2.0", default-features = false }
+poseidon-parameters = { git = "https://github.com/dangush/poseidon377.git", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod poseidontree;
+pub mod poseidontree;
 
 use ark_crypto_primitives::crh::{
     pedersen::{

--- a/src/poseidontree.rs
+++ b/src/poseidontree.rs
@@ -1,16 +1,17 @@
 // use crate::crh::{CRHScheme, TwoToOneCRHScheme};
-// use crate::sponge::poseidon::{PoseidonConfig, PoseidonSponge};
+pub use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
 use ark_crypto_primitives::{crh::{bowe_hopwood::constraints::ParametersVar, poseidon::{constraints::{CRHGadget as PoseidonCRHGadget, TwoToOneCRHGadget as PoseidonTwoToOneCRHGadget}, TwoToOneCRH as PoseidonTwoToOneCRH, CRH as PoseidonCRH}}, merkle_tree::{constraints::PathVar, MerkleTree, Path}};
 use ark_crypto_primitives::crh::{CRHScheme, CRHSchemeGadget, TwoToOneCRHScheme, TwoToOneCRHSchemeGadget};
 use ark_crypto_primitives::merkle_tree::constraints::ConfigGadget;
 use ark_crypto_primitives::merkle_tree::{Config, IdentityDigestConverter};
-use ark_ed_on_bls12_377::{constraints::FqVar, Fq};
+// use ark_ed_on_bls12_377::{constraints::FqVar, Fq};
+use decaf377::Fq;
 use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar, prelude::Boolean, uint8::UInt8};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_r1cs_std::eq::EqGadget;
 use ark_crypto_primitives::crh::poseidon::constraints::CRHParametersVar;
 
-struct Poseidon377MerkleTreeParams;
+pub struct Poseidon377MerkleTreeParams;
 
 // TODO fix this
 // type Leaf = [u8];
@@ -54,17 +55,17 @@ impl ConfigGadget<Poseidon377MerkleTreeParams, Fq> for Poseidon377MerkleTreePara
     type TwoToOneHash = PoseidonTwoToOneCRHGadget<Fq>;
 }
 
-type Poseidon377MerkleTree = MerkleTree<Poseidon377MerkleTreeParams>;
-type Poseidon377MerklePath = Path<Poseidon377MerkleTreeParams>;
-type Poseidon377MerklePathVar =
+pub type Poseidon377MerkleTree = MerkleTree<Poseidon377MerkleTreeParams>;
+pub type Poseidon377MerklePath = Path<Poseidon377MerkleTreeParams>;
+pub type Poseidon377MerklePathVar =
     PathVar<Poseidon377MerkleTreeParams, Fq, Poseidon377MerkleTreeParamsVar>;
 
-type LeafHashParams = <LeafHash as CRHScheme>::Parameters;
+pub type LeafHashParams = <LeafHash as CRHScheme>::Parameters;
 type LeafHashParamsVar = <PoseidonCRHGadget<Fq> as CRHSchemeGadget<LeafHash, Fq>>::OutputVar;
-type TwoToOneHashParams = <TwoToOneHash as TwoToOneCRHScheme>::Parameters;
+pub type TwoToOneHashParams = <TwoToOneHash as TwoToOneCRHScheme>::Parameters;
 type TwoToOneHashParamsVar = <PoseidonTwoToOneCRHGadget<Fq> as TwoToOneCRHSchemeGadget<TwoToOneHash, Fq>>::ParametersVar;
 
-type Root = InnerDigest;
+pub type Root = InnerDigest;
 type RootVar = InnerDigestVar;
 
 struct MerkleTreeVerification {
@@ -123,8 +124,6 @@ mod test {
 
         // Let's set up an RNG for use within tests. Note that this is *not* safe
         // for any production use.
-        let mut rng = ark_std::test_rng();
-
         let (mds, ark) = {
             let mut test_rng = ark_std::test_rng();
 

--- a/src/poseidontree.rs
+++ b/src/poseidontree.rs
@@ -1,7 +1,9 @@
 // use crate::crh::{CRHScheme, TwoToOneCRHScheme};
 pub use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
 use ark_crypto_primitives::{crh::{bowe_hopwood::constraints::ParametersVar, poseidon::{constraints::{CRHGadget as PoseidonCRHGadget, TwoToOneCRHGadget as PoseidonTwoToOneCRHGadget}, TwoToOneCRH as PoseidonTwoToOneCRH, CRH as PoseidonCRH}}, merkle_tree::{constraints::PathVar, MerkleTree, Path}};
-use ark_crypto_primitives::crh::{CRHScheme, CRHSchemeGadget, TwoToOneCRHScheme, TwoToOneCRHSchemeGadget};
+use ark_crypto_primitives::crh::{CRHSchemeGadget, TwoToOneCRHSchemeGadget};
+// reexport
+pub use ark_crypto_primitives::crh::{TwoToOneCRHScheme, CRHScheme};
 use ark_crypto_primitives::merkle_tree::constraints::ConfigGadget;
 use ark_crypto_primitives::merkle_tree::{Config, IdentityDigestConverter};
 // use ark_ed_on_bls12_377::{constraints::FqVar, Fq};
@@ -17,12 +19,12 @@ pub struct Poseidon377MerkleTreeParams;
 // type Leaf = [u8];
 type Leaf = [Fq];
 
-type LeafHash = PoseidonCRH<Fq>;
-type TwoToOneHash = PoseidonTwoToOneCRH<Fq>;
+pub type LeafHash = PoseidonCRH<Fq>;
+pub type TwoToOneHash = PoseidonTwoToOneCRH<Fq>;
 
 type LeafDigest = <LeafHash as CRHScheme>::Output;
 type InnerDigest = <TwoToOneHash as TwoToOneCRHScheme>::Output;
-type LeafInnerDigestConverter = IdentityDigestConverter<Fq>;
+pub type LeafInnerDigestConverter = IdentityDigestConverter<Fq>;
 
 impl Config for Poseidon377MerkleTreeParams {
     type Leaf = Leaf;
@@ -111,42 +113,76 @@ impl ConstraintSynthesizer<Fq> for MerkleTreeVerification {
 }
 
 
+/// The const input for an [`SettlementProof`].
+#[derive(Clone, Debug)]
+pub struct SettlementProofConst {
+    // Poseidon CRH constants that will be embedded into the circuit
+    pub leaf_crh_params: LeafHashParams,
+    pub two_to_one_crh_params: TwoToOneHashParams,
+}
+
+use poseidon377::{RATE_1_PARAMS, RATE_2_PARAMS};
+use poseidon_parameters::v1::Matrix;
+
+impl Default for SettlementProofConst {
+    fn default() -> Self {
+        // fixme: unsafe alpha conversion?
+        let leaf_crh_params = {
+            let params = RATE_1_PARAMS;
+            PoseidonConfig::<Fq>::new(
+                params.rounds.full(),
+                params.rounds.partial(),
+                u32::from_le_bytes(params.alpha.to_bytes_le()).into(),
+                params.mds.0 .0.into_nested_vec(),
+                params.arc.0.into_nested_vec(),
+                1,
+                1,
+            )
+        };
+        let two_to_one_crh_params = {
+            let params = RATE_2_PARAMS;
+            PoseidonConfig::<Fq>::new(
+                params.rounds.full(),
+                params.rounds.partial(),
+                u32::from_le_bytes(params.alpha.to_bytes_le()).into(),
+                params.mds.0 .0.into_nested_vec(),
+                params.arc.0.into_nested_vec(),
+                2,
+                1,
+            )
+        };
+        Self {
+            leaf_crh_params,
+            two_to_one_crh_params,
+        }
+    }
+}
+
+pub trait MatrixExt {
+    fn into_nested_vec(self) -> Vec<Vec<Fq>>;
+}
+
+impl<const N_ROWS: usize, const N_COLS: usize, const N_ELEMENTS: usize> MatrixExt
+    for Matrix<N_ROWS, N_COLS, N_ELEMENTS>
+{
+    fn into_nested_vec(self) -> Vec<Vec<Fq>> {
+        self.elements
+            .chunks(N_COLS)
+            .map(|row| row.to_vec())
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
-    use ark_std::rand::RngCore; // Needed to generate mds and ark
-
     use super::*;
 
     #[test]
     fn merkle_tree_constraints_correctness() {
         use ark_relations::r1cs::ConstraintSystem;
 
-        // Let's set up an RNG for use within tests. Note that this is *not* safe
-        // for any production use.
-        let (mds, ark) = {
-            let mut test_rng = ark_std::test_rng();
-
-            let mut mds = vec![vec![]; 3];
-            for i in 0..3 {
-                for _ in 0..3 {
-                    mds[i].push(Fq::from(test_rng.next_u64()));
-                }
-            }
-    
-            let mut ark = vec![vec![]; 8 + 24];
-            for i in 0..8 + 24 {
-                for _ in 0..3 {
-                    ark[i].push(Fq::from(test_rng.next_u64()));
-                }
-            }
-
-            (mds, ark)
-        };
-
         // First, let's sample the public parameters for the hash functions:
-        let leaf_crh_params = PoseidonConfig::<Fq>::new(8, 24, 31, mds.clone(), ark.clone(), 2, 1);
-        let two_to_one_crh_params = PoseidonConfig::<Fq>::new(8, 24, 31, mds, ark, 2, 1);
+        let poseidon_constants = SettlementProofConst::default();
 
         // TODO: remove when `Leaf` is redefined to u8
         // Convert u8 values to Fq
@@ -158,8 +194,8 @@ mod test {
         // Next, let's construct our tree.
         // This follows the API in https://github.com/arkworks-rs/crypto-primitives/blob/6be606259eab0aec010015e2cfd45e4f134cd9bf/src/merkle_tree/mod.rs#L156
         let tree = Poseidon377MerkleTree::new(
-            &leaf_crh_params,
-            &two_to_one_crh_params,
+            &poseidon_constants.leaf_crh_params,
+            &poseidon_constants.two_to_one_crh_params,
             // [1u8, 2u8, 3u8, 10u8, 9u8, 17u8, 70u8, 45u8].map(|u| [u]), // the i-th entry is the i-th leaf.
             leaves,
         )
@@ -174,8 +210,8 @@ mod test {
 
         let circuit = MerkleTreeVerification {
             // constants
-            leaf_crh_params,
-            two_to_one_crh_params,
+            leaf_crh_params: poseidon_constants.leaf_crh_params,
+            two_to_one_crh_params: poseidon_constants.two_to_one_crh_params,
 
             // public inputs
             root,


### PR DESCRIPTION
## Summary 

The goal is to generate merkle inclusion proofs using the arkworks MerkleTree type and Poseidon377 hash function. 

## Todos
- [ ] Get MVP compiling and passing constraints test
- [ ] Change `Leaf` type to `[u8]` and handle generating `Fq` digest
- [ ] Use params from Penumbra's `Poseidon377` implementation using `decaf377`